### PR TITLE
Modify the code for "greatest"

### DIFF
--- a/ujr.ahk
+++ b/ujr.ahk
@@ -483,7 +483,7 @@ Loop{
 					} else if (merge == 2){
 						; "Greatest" merge
 						if (axis1_controls_special_%index% == "None"){
-							if (abs(tmp1 - 50) > abs(tmp2 - 50)){
+							if ( tmp1 > tmp2 ){
 								val2 := val
 							}
 						} else {


### PR DESCRIPTION
- This is necessary to work properly where the joystick outputs are 0-100.
- However, without using "abs" this is obviously now broken for inputs that can be negative.
- I was unable to test that situation but I think the problem may have been the "-50" rather than abs function.
